### PR TITLE
Chore: Add devops

### DIFF
--- a/.github/workflows/.ci-cd.yml
+++ b/.github/workflows/.ci-cd.yml
@@ -2,6 +2,7 @@ name: Github Action to Lint, test, deploy and release
 on:
   push:
     branches: [main]
+    tags: ["*"]
 
 permissions:
   contents: read
@@ -39,6 +40,7 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     needs: test
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -58,9 +60,8 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/.ci-cd.yml
+++ b/.github/workflows/.ci-cd.yml
@@ -1,0 +1,70 @@
+name: Github Action to Lint, test, deploy and release
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64
+          args: --fast # Enable only fast linters
+          # Can be replace by '--enable-all' to enable all linters
+          # Or enable presets of linters by '--presets <string>' see https://golangci-lint.run/usage/configuration/#linters-configuration
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Download dependencies
+        run: go mod tidy
+      - name: Run tests
+        run: go test ./... -v
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+      - name: Build binary
+        run: |
+          cd cmd/mule
+          CGO_ENABLED=0 GOOS=linux go build -o bin/mule
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: mule-binary
+          path: mule
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: mule-binary
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: mule

--- a/.github/workflows/.ci-cd.yml
+++ b/.github/workflows/.ci-cd.yml
@@ -49,7 +49,7 @@ jobs:
           cd cmd/mule
           CGO_ENABLED=0 GOOS=linux go build -o bin/mule
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mule-binary
           path: mule
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: mule-binary
       - name: Create Release

--- a/.github/workflows/.ci-cd.yml
+++ b/.github/workflows/.ci-cd.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mule-binary
-          path: mule
+          path: cmd/mule/bin/mule
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/.ci-cd.yml
+++ b/.github/workflows/.ci-cd.yml
@@ -58,6 +58,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: build
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
       - name: Download artifact

--- a/.github/workflows/.ci-cd.yml
+++ b/.github/workflows/.ci-cd.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
     tags: ["*"]
+  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/.ci-cd.yml
+++ b/.github/workflows/.ci-cd.yml
@@ -5,7 +5,7 @@ on:
     tags: ["*"]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   lint:

--- a/.github/workflows/.ci-cd.yml
+++ b/.github/workflows/.ci-cd.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Hello :wave:
I'm opening this PR to resolve #26.

# Linting
For the linting part, I added a job using `golangci-lint`.
I included the `--fast` argument, which enables only fast linters.
I also added comments to indicate that this argument can be modified to better suit the project's needs.
See: [golangci-lint configuration](https://golangci-lint.run/usage/configuration/#linters-configuration).

# Testing
For the testing part, I simply added `go test` to run the existing test files.

# Build & Release
For deployment, I used the same command as in the Makefile, which generates a "mule" release file.

Since no specific trigger was mentioned for the workflow, I added:
```
on:
  push:
    branches: [main]
    tags: ["*"]
```
I also added `if: startsWith(github.ref, 'refs/tags/')` to the build job and `needs: build` to the release job
This ensures that the build and release jobs are only triggered when a tag is pushed.

I hope this meets your needs! Let me know if any adjustments are required :pray: 
